### PR TITLE
Fix regex to account for dot in ddb table name

### DIFF
--- a/src/dynamodb.js
+++ b/src/dynamodb.js
@@ -3,7 +3,7 @@ const aws = require('aws-sdk');
 const assert = require('assert');
 
 const getTableNameFromArn = (sourceARN) => {
-    const found = sourceARN.match(/arn:aws:dynamodb:[^:]+:[0-9]+:table\/([\w-]+)\/.*/);
+    const found = sourceARN.match(/arn:aws:dynamodb:[^:]+:[0-9]+:table\/([\w-.]+)\/.*/);
     assert(found[1] !== undefined, 'Failed to parse ARN to extract table name:' + sourceARN);
     return found[1];
 };

--- a/tst/dynamodb.js
+++ b/tst/dynamodb.js
@@ -1,0 +1,34 @@
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+const dynamodb = require("../src/dynamodb");
+
+describe('dynamodb.getTableNameFromArn', () => {
+    describe('table name has alphanumeric only', () => {
+        it('simple table name', () => {
+            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable123/stream/2015–05–11T21:21:33.291";
+            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable123');
+        })
+    });
+
+    describe('table name has dash', () => {
+        it('table name with dash', () => {
+            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable-123/stream/2015–05–11T21:21:33.291";
+            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable-123');
+        })
+    });
+
+    describe('table name has underscore', () => {
+        it('table name with underscore', () => {
+            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable_123/stream/2015–05–11T21:21:33.291";
+            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable_123');
+        })
+    });
+
+    describe('table name has dot', () => {
+        it('table name with dot', () => {
+            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable.123/stream/2015–05–11T21:21:33.291";
+            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable.123');
+        })
+    });
+});

--- a/tst/index.js
+++ b/tst/index.js
@@ -6,6 +6,7 @@ chai.use(require('sinon-chai'));
 const path = require('path');
 const fs = require('fs');
 const AWS = require('aws-sdk-mock');
+const dynamodb = require('../src/dynamodb');
 AWS.setSDK(path.resolve('node_modules/aws-sdk'));
 
 const EVENTS = {
@@ -229,5 +230,35 @@ describe('index.handler', () => {
                 expect(err.message).to.equal('FAILURE');
             }
         });
+    });
+});
+
+describe('dynamodb.getTableNameFromArn', () => {
+    describe('table name has alphanumeric only', () => {
+        it('simple table name', () => {
+            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable123/stream/2015–05–11T21:21:33.291";
+            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable123');
+        })
+    });
+
+    describe('table name has dash', () => {
+        it('table name with dash', () => {
+            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable-123/stream/2015–05–11T21:21:33.291";
+            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable-123');
+        })
+    });
+
+    describe('table name has underscore', () => {
+        it('table name with underscore', () => {
+            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable_123/stream/2015–05–11T21:21:33.291";
+            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable_123');
+        })
+    });
+
+    describe('table name has dot', () => {
+        it('table name with dot', () => {
+            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable.123/stream/2015–05–11T21:21:33.291";
+            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable.123');
+        })
     });
 });

--- a/tst/index.js
+++ b/tst/index.js
@@ -6,7 +6,6 @@ chai.use(require('sinon-chai'));
 const path = require('path');
 const fs = require('fs');
 const AWS = require('aws-sdk-mock');
-const dynamodb = require('../src/dynamodb');
 AWS.setSDK(path.resolve('node_modules/aws-sdk'));
 
 const EVENTS = {
@@ -233,32 +232,3 @@ describe('index.handler', () => {
     });
 });
 
-describe('dynamodb.getTableNameFromArn', () => {
-    describe('table name has alphanumeric only', () => {
-        it('simple table name', () => {
-            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable123/stream/2015–05–11T21:21:33.291";
-            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable123');
-        })
-    });
-
-    describe('table name has dash', () => {
-        it('table name with dash', () => {
-            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable-123/stream/2015–05–11T21:21:33.291";
-            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable-123');
-        })
-    });
-
-    describe('table name has underscore', () => {
-        it('table name with underscore', () => {
-            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable_123/stream/2015–05–11T21:21:33.291";
-            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable_123');
-        })
-    });
-
-    describe('table name has dot', () => {
-        it('table name with dot', () => {
-            const tableName = "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable.123/stream/2015–05–11T21:21:33.291";
-            expect(dynamodb.getTableNameFromArn(tableName)).to.equal('TestTable.123');
-        })
-    });
-});


### PR DESCRIPTION
*Issue #, if available:*
This PR fixes the issue https://github.com/aws-samples/dynamodb-history-storer/issues/15

*Description of changes:*
As per the dynamodb documentation the dot is a valid character in the table name. However current regex doesn't account for that and hence when a table name has dot in it, it fails.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
